### PR TITLE
Allow configuring target species that are always predicted

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Each element always contains  field called "filepath"; the exact content of thos
             "classifications": {  => dict (optional)  => Top-5 classifications. Included only if "CLASSIFIER" if not part of the "failures" field.
                 "classes": list[str]  => List of top-5 classes predicted by the classifier, matching the decreasing order of their scores below.
                 "scores": list[float]  => List of scores corresponding to top-5 classes predicted by the classifier, in decreasing order.
+                "target_classes": list[str] (optional)  => List of target classes, only present if target classes are passed as arguments.
+                "target_logits": list[float] (optional)  => Raw confidence scores (logits) of the target classes, only present if target classes are passed as arguments.
             },
             "detections": [  => list (optional)  => List of detections with confidence scores > 0.01, in decreasing order of their scores. Included only if "DETECTOR" if not part of the "failures" field.
                 {
@@ -265,6 +267,8 @@ Each element always contains  field called "filepath"; the exact content of thos
             "classifications": {  => dict (optional)  => Top-5 classifications. Included only if "CLASSIFIER" if not part of the "failures" field.
                 "classes": list[str]  => List of top-5 classes predicted by the classifier, matching the decreasing order of their scores below.
                 "scores": list[float]  => List of scores corresponding to top-5 classes predicted by the classifier, in decreasing order.
+                "target_classes": list[str] (optional)  => List of target classes, only present if target classes are passed as arguments.
+                "target_logits": list[float] (optional)  => Raw confidence scores (logits) of the target classes, only present if target classes are passed as arguments.
             }
         },
         ...  => A response will contain one prediction for each instance in the request.

--- a/speciesnet/classifier.py
+++ b/speciesnet/classifier.py
@@ -46,7 +46,9 @@ class SpeciesNetClassifier:
     MAX_CROP_RATIO = 0.3
     MAX_CROP_SIZE = 400
 
-    def __init__(self, model_name: str) -> None:
+    def __init__(
+        self, model_name: str, target_species_txt: Optional[str] = None
+    ) -> None:
         """Loads the classifier resources.
 
         Args:
@@ -67,6 +69,16 @@ class SpeciesNetClassifier:
         )
         with open(self.model_info.classifier_labels, mode="r", encoding="utf-8") as fp:
             self.labels = {idx: line.strip() for idx, line in enumerate(fp.readlines())}
+
+        if target_species_txt is not None:
+            with open(target_species_txt, mode="r", encoding="utf-8") as fp:
+                self.target_labels = [
+                    line.strip()
+                    for line in fp.readlines()
+                    if line.strip() in self.labels.values()
+                ]
+            labels_to_idx = {label: idx for idx, label in self.labels.items()}
+            self.target_idx = [labels_to_idx[label] for label in self.target_labels]
 
         end_time = time.time()
         logging.info(
@@ -223,5 +235,15 @@ class SpeciesNetClassifier:
                     "scores": scores_arr.tolist(),
                 },
             }
+
+            if hasattr(self, "target_idx"):
+                predictions[filepath]["classifications"].update(
+                    {
+                        "target_classes": self.target_labels,
+                        "target_logits": [
+                            float(logits[0][idx]) for idx in self.target_idx
+                        ],
+                    }
+                )
 
         return [predictions[filepath] for filepath in filepaths]

--- a/speciesnet/multiprocessing.py
+++ b/speciesnet/multiprocessing.py
@@ -560,6 +560,7 @@ class SpeciesNet:
         *,
         components: Literal["all", "classifier", "detector", "ensemble"] = "all",
         geofence: bool = True,
+        target_species_txt: Optional[str] = None,
         combine_predictions_fn: Callable = combine_predictions_for_single_item,
         multiprocessing: bool = False,
     ) -> None:
@@ -574,6 +575,9 @@ class SpeciesNet:
             geofence:
                 Whether to enable geofencing during ensemble prediction. Defaults to
                 `True`.
+            target_species_txt:
+                Path to a text file containing the target species to always output
+                classification scores for. Optional.
             combine_predictions_fn:
                 Function to tell the ensemble how to combine predictions from the
                 individual model components (e.g. classifications, detections etc.)
@@ -585,7 +589,7 @@ class SpeciesNet:
             self.manager = SyncManager()
             self.manager.start()  # pylint: disable=consider-using-with
             if components in ["all", "classifier"]:
-                self.classifier = self.manager.Classifier(model_name)  # type: ignore
+                self.classifier = self.manager.Classifier(model_name, target_species_txt=target_species_txt)  # type: ignore
             if components in ["all", "detector"]:
                 self.detector = self.manager.Detector(model_name)  # type: ignore
             if components in ["all", "ensemble"]:
@@ -597,7 +601,9 @@ class SpeciesNet:
         else:
             self.manager = None
             if components in ["all", "classifier"]:
-                self.classifier = SpeciesNetClassifier(model_name)
+                self.classifier = SpeciesNetClassifier(
+                    model_name, target_species_txt=target_species_txt
+                )
             if components in ["all", "detector"]:
                 self.detector = SpeciesNetDetector(model_name)
             if components in ["all", "ensemble"]:

--- a/speciesnet/scripts/run_model.py
+++ b/speciesnet/scripts/run_model.py
@@ -95,6 +95,11 @@ _ADMIN1_REGION = flags.DEFINE_string(
     "First-level administrative division (in ISO 3166-2 format, e.g. 'CA') to enforce on all "
     "instances.",
 )
+_TARGET_SPECIES_TXT = flags.DEFINE_string(
+    "target_species_txt",
+    None,
+    "Input TXT file with species of interest to always compute classification scores for.",
+)
 _CLASSIFICATIONS_JSON = flags.DEFINE_string(
     "classifications_json",
     None,
@@ -340,6 +345,14 @@ def main(argv: list[str]) -> None:
         ):
             return
 
+    # If a list of target species is given, check that it exists
+    if _TARGET_SPECIES_TXT.value is not None and not local_file_exists(
+        _TARGET_SPECIES_TXT.value
+    ):
+        raise RuntimeError(
+            f"Target species file '{_TARGET_SPECIES_TXT.value}' specified via --{_PREDICTIONS_JSON.name} does not exist."
+        )
+
     # Load classifications and/or detections from previous runs.
     classifications_dict, _ = load_partial_predictions(
         _CLASSIFICATIONS_JSON.value, instances_dict["instances"]
@@ -357,6 +370,7 @@ def main(argv: list[str]) -> None:
         _MODEL.value,
         components=components,
         geofence=_GEOFENCE.value,
+        target_species_txt=_TARGET_SPECIES_TXT.value,
         # Uncomment the line below if you want to run your own custom ensembling
         # routine. And also, implement that routine! :-)
         # combine_predictions_fn=custom_combine_predictions_fn,


### PR DESCRIPTION
This PR adds the option to specify a set of species ("target species") for which the classifier will always output the raw classification scores (logits), irrespective of whether they are within the top-scoring set or not. Specifically, this PR:

- adds a commandline option in `speciesnet/scripts/run_model.py` to specify a text file containing target species in the same format as the existing taxonomy.txt files
- adapts SpeciesNetClassifier to parse this file (if present) and always add logits for those target classes to the output
- adapts output documentation in the README accordingly