### PR TITLE
Add return type annotation to torch_test() function

### DIFF
--- a/speciesnet/scripts/gpu_test.py
+++ b/speciesnet/scripts/gpu_test.py
@@ -15,7 +15,9 @@
 """Script to check GPU availability for PyTorch in the current Python environment."""
 
 
-def torch_test():
+from typing import Optional
+
+def torch_test() -> Optional[int]:
     """Print diagnostic information about Torch/CUDA status, including Torch/CUDA
     versions and all available CUDA device names.
     """


### PR DESCRIPTION
## Background
The public function `torch_test()` in `speciesnet/scripts/gpu_test.py` lacks a return type annotation. This omission reduces code clarity and can cause issues with type checking tools (e.g., `mypy`), impacting maintainability in this Python codebase.

## Changes
Added a return type annotation `Optional[int]` to the `torch_test()` function, as it may return `None` (if PyTorch import fails) or an integer representing the number of CUDA devices detected. Also imported `Optional` from the `typing` module to support this annotation.

## Verification
This change is a pure type hint addition and does not alter the runtime behavior or API. It can be verified through code review, running existing tests, or using static type checkers if integrated into the project.