### PR TITLE
Bump maximum Python version to 3.14

### DIFF
--- a/.github/workflows/markdown_style_checks.yml
+++ b/.github/workflows/markdown_style_checks.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read      # required by actions/checkout
+  pull-requests: read # required by dorny/paths-filter
 jobs:
   run_style_checks:
     runs-on: ${{ matrix.os }}
@@ -15,9 +18,9 @@ jobs:
         python-version: ['3.12']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Look out for file changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           filters: |
@@ -25,7 +28,7 @@ jobs:
               - '**/*.md'
               - '.github/workflows/**'
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.target_files == 'true'
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/python_style_checks.yml
+++ b/.github/workflows/python_style_checks.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read      # required by actions/checkout
+  pull-requests: read # required by dorny/paths-filter
 jobs:
   run_style_checks:
     runs-on: ${{ matrix.os }}
@@ -12,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.12']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Look out for file changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           filters: |
@@ -25,7 +28,7 @@ jobs:
               - '**/*.py'
               - '.github/workflows/**'
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.target_files == 'true'
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read      # required by actions/checkout
+  pull-requests: read # required by dorny/paths-filter
 jobs:
   run_tests:
     runs-on: ${{ matrix.os }}
@@ -16,9 +19,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Look out for file changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         with:
           filters: |
@@ -26,7 +29,7 @@ jobs:
               - '**/*.py'
               - '.github/workflows/**'
       - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.changes.outputs.target_files == 'true'
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   run_tests:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 720
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -40,4 +40,4 @@ jobs:
       - name: Run tests with pytest
         if: steps.changes.outputs.target_files == 'true'
         run: |
-          pytest -vv --suppress-no-test-exit-code
+          pytest -vv --suppress-no-test-exit-code --timeout=900 --timeout-method=thread

--- a/advanced_topics.md
+++ b/advanced_topics.md
@@ -152,11 +152,9 @@ The main README describes the typical output format for run_model, when you are 
 
 ## Contributing code
 
-If you're interested in contributing to our repo, rather than installing via pip, we recommend cloning the repo, then creating the Python virtual environment for development using the following commands:
+If you're interested in contributing to our repo, rather than installing via pip, we recommend cloning the repo, creating a Python virtual environment for development, and installing the package locally using the following command:
 
 ```bash
-python -m venv .env
-source .env/bin/activate
 pip install -e .[dev]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,12 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]
-requires-python = ">= 3.9, < 3.14"
+requires-python = ">= 3.9, < 3.15"
 dependencies = [
     "absl-py",
     "cloudpathlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,11 @@ dependencies = [
     "requests",
     "reverse_geocoder",
     "tqdm",
-    "torch >= 2.0",
+    # torch 2.14.0 deadlocks during multi-threaded/multi-process inference on
+    # macOS; 2.13.0 is the last version verified to work. Reproduced on macOS 15
+    # (arm64, MPS) with Python 3.10 through 3.14. Linux and Windows are unaffected.
+    "torch >= 2.0, < 2.14 ; sys_platform == 'darwin'",
+    "torch >= 2.0 ; sys_platform != 'darwin'",
     "yolov5 >= 7.0.8, < 7.0.12",
     "setuptools<82"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
 github = [
     "speciesnet[dev]",
     "pytest-custom_exit_code",
+    "pytest-timeout",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR does three things, none touching code:

* Raises the maximum Python version to 3.14
* Specifies GH workflow actions by commit hash, rather than by version, to comply with new organizational rules
* Pins PyTorch to <2.14 on MacOS; in some environments, torch 2.14 causes crashes on MacOS (will address in a later PR)