### PR TITLE
Serialize MPS inference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,7 @@ dependencies = [
     "requests",
     "reverse_geocoder",
     "tqdm",
-    # torch 2.14.0 deadlocks during multi-threaded/multi-process inference on
-    # macOS; 2.13.0 is the last version verified to work. Reproduced on macOS 15
-    # (arm64, MPS) with Python 3.10 through 3.14. Linux and Windows are unaffected.
-    "torch >= 2.0, < 2.14 ; sys_platform == 'darwin'",
-    "torch >= 2.0 ; sys_platform != 'darwin'",
+    "torch >= 2.0",
     "yolov5 >= 7.0.8, < 7.0.12",
     "setuptools<82"
 ]

--- a/speciesnet/classifier.py
+++ b/speciesnet/classifier.py
@@ -34,6 +34,7 @@ import torch
 import torchvision.transforms.functional as F
 
 from speciesnet.constants import Failure
+from speciesnet.constants import mps_inference_lock
 from speciesnet.utils import BBox
 from speciesnet.utils import ModelInfo
 from speciesnet.utils import PreprocessedImage
@@ -244,8 +245,11 @@ class SpeciesNetClassifier:
             return list(predictions.values())
         batch_arr = np.stack(batch_arr, axis=0, dtype=np.float32)
 
-        batch_tensor = torch.from_numpy(batch_arr).to(self.device)
-        logits = self.model(batch_tensor).cpu()
+        # On MPS devices, make sure all MPS operations happen serially.  This
+        # lock is a no-op on non-MPS devices.
+        with mps_inference_lock(self.device):
+            batch_tensor = torch.from_numpy(batch_arr).to(self.device)
+            logits = self.model(batch_tensor).cpu()
         scores = torch.softmax(logits, dim=-1)
         scores, indices = torch.topk(scores, k=5, dim=-1)
 

--- a/speciesnet/constants.py
+++ b/speciesnet/constants.py
@@ -17,10 +17,13 @@
 __all__ = [
     "Classification",
     "Detection",
+    "mps_inference_lock",
 ]
 
+import contextlib
 import enum
-from typing import Optional
+import threading
+from typing import Iterator, Optional
 
 
 class Classification(str, enum.Enum):
@@ -72,3 +75,37 @@ class Failure(enum.Flag):
     CLASSIFIER = enum.auto()
     DETECTOR = enum.auto()
     GEOLOCATION = enum.auto()
+
+
+# PyTorch's MPS backend shares a single Metal command buffer per process, and a
+# Metal command buffer cannot be encoded from more than one thread at a time.
+# The inference pipeline runs the detector and the classifier concurrently, and
+# both models live in the same process whether or not multiprocessing is enabled,
+# since with multiprocessing they are both hosted by the same SyncManager server.
+#
+# This lock guards both inference calls with a process-wide lock (only on MPS).
+_MPS_INFERENCE_LOCK = threading.Lock()
+
+
+@contextlib.contextmanager
+def mps_inference_lock(device: str) -> Iterator[None]:
+    """Serializes model inference when running on MPS.
+
+    Callers must hold this across the whole inference call, including moving inputs
+    onto the device and moving results back off it. MPS work is asynchronous, so
+    releasing the lock before the results have been transferred would leave work
+    queued on the shared command buffer and defeat the purpose.
+
+    Args:
+        device:
+            Device inference is about to run on, e.g. "cpu", "cuda" or "mps".
+
+    Yields:
+        Nothing. On devices other than MPS this is a no-op and acquires no lock.
+    """
+
+    if device != "mps":
+        yield
+        return
+    with _MPS_INFERENCE_LOCK:
+        yield

--- a/speciesnet/detector.py
+++ b/speciesnet/detector.py
@@ -39,6 +39,7 @@ except ImportError:
 
 from speciesnet.constants import Detection
 from speciesnet.constants import Failure
+from speciesnet.constants import mps_inference_lock
 from speciesnet.utils import ModelInfo
 from speciesnet.utils import PreprocessedImage
 
@@ -186,12 +187,14 @@ class SpeciesNetDetector:
         img_tensor = torch.from_numpy(img.arr / 255)
         img_tensor = img_tensor.permute([2, 0, 1])  # HWC to CHW.
         batch_tensor = torch.unsqueeze(img_tensor, 0).float()  # CHW to NCHW.
-        batch_tensor = batch_tensor.to(self.device)
 
-        # Run inference.
-        results = self.model(batch_tensor, augment=False)[0]
-        if self.device == "mps":
-            results = results.cpu()
+        # On MPS devices, make sure all MPS operations happen serially.  This
+        # lock is a no-op on non-MPS devices.
+        with mps_inference_lock(self.device):
+            batch_tensor = batch_tensor.to(self.device)
+            results = self.model(batch_tensor, augment=False)[0]
+            if self.device == "mps":
+                results = results.cpu()
         results = yolov5_non_max_suppression(
             prediction=results,
             conf_thres=SpeciesNetDetector.DETECTION_THRESHOLD,


### PR DESCRIPTION
As of torch 2.14, having two separate MPS buffers active simultaneously is a no-no.  This caused run_model to crash on Apple silicon.  Fixed with a lock that is a no-op on non-MPS devices.